### PR TITLE
Add issue templates for runner requests and bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,52 @@
+name: Bug Report
+description: Report a problem with the gallery site, a runner asset, or the validation script.
+title: '[Bug] '
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+        For issues with the **RunCat Neo menubar app itself**, please file them at the [RunCat Neo repository](https://github.com/runcat-dev/RunCatNeo/issues) instead.
+  - type: dropdown
+    id: where
+    attributes:
+      label: Where does the bug occur?
+      options:
+        - Gallery site (https://runcat-dev.github.io/RunnerGallery/)
+        - A specific runner's asset (frames or preview)
+        - Validation script / CI
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual behavior
+      description: What did you expect to happen, and what happened instead?
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Browser / OS (if gallery bug)
+      placeholder: Safari 18 on macOS 15
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues (open and closed) and confirmed this bug has not already been reported.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: RunCat Neo app issues
+    url: https://github.com/runcat-dev/RunCatNeo/issues
+    about: For bugs or requests about the RunCat Neo menubar app itself, please file them there instead.

--- a/.github/ISSUE_TEMPLATE/runner-request.yml
+++ b/.github/ISSUE_TEMPLATE/runner-request.yml
@@ -1,0 +1,56 @@
+name: Runner Request
+description: Request a new custom runner or a revival of a classic RunCat runner.
+title: 'Request: add the "___" runner'
+labels: ["runner-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a runner! Please fill in the fields below.
+        If you plan to submit the runner yourself, see [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
+  - type: input
+    id: runner-name
+    attributes:
+      label: Proposed runner name
+      description: A short descriptive name (e.g. "Panda", "Steam Locomotive"). It does not have to be the final directory name.
+      placeholder: Panda
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind of request
+      options:
+        - Revival of a classic RunCat runner
+        - Completely new runner
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What should this runner look like and how should it move? Attach reference images or animations if you have them.
+      placeholder: A silhouette of a running panda with...
+    validations:
+      required: true
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Are you planning to submit a PR yourself?
+      options:
+        - Yes — I'll open a PR
+        - Maybe
+        - No — I'm requesting for someone else to make it
+    validations:
+      required: true
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues (open and closed) and confirmed this runner has not already been requested.
+          required: true
+        - label: This runner does NOT contain third-party intellectual property (e.g. Pokémon, Mario, or other copyrighted/trademarked characters).
+          required: true
+        - label: I have read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) if I'm planning to submit a PR.
+          required: false


### PR DESCRIPTION
## Summary

Introduces GitHub Issue Forms under `.github/ISSUE_TEMPLATE/` so issue authors are guided to the right fields upfront.

- **Runner Request** (`runner-request.yml`) — the dominant use case in past issues. Auto-labels `runner-request`. Requires the author to declare it as a revival or a new runner, describe the runner, and state whether they'll open the PR themselves.
- **Bug Report** (`bug-report.yml`) — auto-labels `bug`. Covers gallery-site, runner-asset, and CI issues.
- **Config** (`config.yml`) — disables blank issues so the checklists cannot be skipped, and adds a contact link redirecting RunCat Neo app bugs to the RunCat Neo repository.

Required checkboxes on both templates enforce:

- confirmation that the author searched existing issues (this is the dedup guard #30 was missing)
- for runner requests, the same 3rd-party IP rule the PR template already carries

## Test plan

- [ ] `Issues > New issue` on GitHub shows two options: **Runner Request** and **Bug Report**.
- [ ] "Open a blank issue" link is gone.
- [ ] The "RunCat Neo app issues" contact link appears in the picker.
- [ ] Submitting either form with a required checklist unticked is blocked by GitHub.
- [ ] A submitted Runner Request has the `runner-request` label attached; a submitted Bug Report has `bug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)